### PR TITLE
修改卡号匹配规则

### DIFF
--- a/creditcard.go
+++ b/creditcard.go
@@ -163,7 +163,7 @@ func (c *Card) MethodValidate() (Company, error) {
 		return Company{"mastercard", "MasterCard"}, nil
 	case ccDigits.At(4) == 4026 || ccDigits.At(6) == 417500 || ccDigits.At(4) == 4405 || ccDigits.At(4) == 4508 || ccDigits.At(4) == 4844 || ccDigits.At(4) == 4913 || ccDigits.At(4) == 4917:
 		return Company{"visa electron", "Visa Electron"}, nil
-	case ccDigits.At(1) == 4:
+	case ccDigits.At(1) == 4 && (ccLen == 13 || ccLen == 16 || ccLen == 19):
 		return Company{"visa", "Visa"}, nil
 	default:
 		return Company{"", ""}, errors.New("Unknown credit card method.")

--- a/creditcard_test.go
+++ b/creditcard_test.go
@@ -1,8 +1,8 @@
 package creditcard
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"fmt"
+	. "github.com/smartystreets/goconvey/convey"
 	"strconv"
 	"testing"
 	"time"
@@ -362,8 +362,25 @@ func TestMethod(t *testing.T) {
 		})
 
 		Convey("Should work for Visa", func() {
-			card := Card{Number: "4242424242", Cvv: "1111", Month: month, Year: year}
+			// 13位
+			card := Card{Number: "4514611983866", Cvv: "1111", Month: month, Year: year}
 			err := card.Method()
+
+			So(err, ShouldBeNil)
+			So(card.Company.Short, ShouldEqual, "visa")
+			So(card.Company.Long, ShouldEqual, "Visa")
+
+			// 16位
+			card = Card{Number: "4514611983866000", Cvv: "1111", Month: month, Year: year}
+			err = card.Method()
+
+			So(err, ShouldBeNil)
+			So(card.Company.Short, ShouldEqual, "visa")
+			So(card.Company.Long, ShouldEqual, "Visa")
+
+			// 19位
+			card = Card{Number: "4514611983866000000", Cvv: "1111", Month: month, Year: year}
+			err = card.Method()
 
 			So(err, ShouldBeNil)
 			So(card.Company.Short, ShouldEqual, "visa")
@@ -381,9 +398,8 @@ func TestMethod(t *testing.T) {
 	})
 }
 
-
 func TestCard(t *testing.T) {
-	card := Card{Number:"36018612345678"}
-	v,err := card.MethodValidate()
-	fmt.Print(v,err)
-	}
+	card := Card{Number: "36018612345678"}
+	v, err := card.MethodValidate()
+	fmt.Print(v, err)
+}


### PR DESCRIPTION
visa的卡号长度有13，16，19.
前端如果传入14，15长度的卡号，也能匹配成功，跟实际不符合。
visa加入了卡号长度判断。
卡号参考网址：https://www.bincodes.com/bin-list/